### PR TITLE
add : 애플로그인 API 연결 및 카카오 회원탈퇴 기능 추가

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -43,7 +43,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.beside04.emotionDiary"
+        applicationId "com.beside04.haruNyang"
         minSdkVersion 22
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.beside04.emotionDiary">
+    package="com.beside04.haruNyang">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.beside04.emotionDiary">
+    package="com.beside04.haruNyang">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -17,6 +17,18 @@
 
                 <!-- Redirect URI, "kakao${YOUR_NATIVE_APP_KEY}://oauth" 형식 -->
                 <data android:scheme="@string/kakao_oauth" android:host="oauth"/>
+            </intent-filter>
+        </activity>
+        <activity
+            android:name="com.aboutyou.dart_packages.sign_in_with_apple.SignInWithAppleCallback"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="signinwithapple" />
+                <data android:path="callback" />
             </intent-filter>
         </activity>
         <activity

--- a/android/app/src/main/kotlin/com/example/frontend/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/frontend/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.beside04.emotionDiary
+package com.beside04.haruNyang
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.beside04.emotionDiary">
+    package="com.beside04.haruNyang">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,6 +11,8 @@ PODS:
     - Flutter
   - shared_preferences_ios (0.0.1):
     - Flutter
+  - sign_in_with_apple (0.0.1):
+    - Flutter
   - Toast (4.0.0)
 
 DEPENDENCIES:
@@ -20,6 +22,7 @@ DEPENDENCIES:
   - kakao_flutter_sdk_common (from `.symlinks/plugins/kakao_flutter_sdk_common/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
+  - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/ios`)
 
 SPEC REPOS:
   trunk:
@@ -38,6 +41,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   shared_preferences_ios:
     :path: ".symlinks/plugins/shared_preferences_ios/ios"
+  sign_in_with_apple:
+    :path: ".symlinks/plugins/sign_in_with_apple/ios"
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
@@ -46,6 +51,7 @@ SPEC CHECKSUMS:
   kakao_flutter_sdk_common: 2fcd2c17ef69300497b9369f390766dd9af0514c
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
+  sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		1F78A069912C2202E1AAEFE4 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		386DE9D8292C6AF800845131 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		4997D41DED6567C4FC128BBF /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -104,6 +105,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				386DE9D8292C6AF800845131 /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -354,15 +356,16 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = TWRZCMQ9RF;
+				DEVELOPMENT_TEAM = XQ24HP64B3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.beside04.emotionDiary;
+				PRODUCT_BUNDLE_IDENTIFIER = com.beside04.haruNyang;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -483,15 +486,16 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = TWRZCMQ9RF;
+				DEVELOPMENT_TEAM = XQ24HP64B3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.beside04.emotionDiary;
+				PRODUCT_BUNDLE_IDENTIFIER = com.beside04.haruNyang;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -506,15 +510,16 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = TWRZCMQ9RF;
+				DEVELOPMENT_TEAM = XQ24HP64B3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.beside04.emotionDiary;
+				PRODUCT_BUNDLE_IDENTIFIER = com.beside04.haruNyang;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/lib/data/repository/social_login_repository/apple_login_impl.dart
+++ b/lib/data/repository/social_login_repository/apple_login_impl.dart
@@ -1,0 +1,28 @@
+import 'package:frontend/domain/repository/social_login_repository/apple_login_repository.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+
+class AppleLoginImpl implements AppleLoginRepository {
+  @override
+  Future<AuthorizationCredentialAppleID?> login() async {
+    AuthorizationCredentialAppleID token;
+    try {
+      //애플 로그인 성공
+      token = await SignInWithApple.getAppleIDCredential(
+        scopes: [
+          AppleIDAuthorizationScopes.email,
+          AppleIDAuthorizationScopes.fullName,
+        ],
+        webAuthenticationOptions: WebAuthenticationOptions(
+          clientId: "haruNyang.beside04.com",
+          redirectUri: Uri.parse(
+            "https://fishy-peat-hyacinth.glitch.me/callbacks/sign_in_with_apple",
+          ),
+        ),
+      );
+      return token;
+    } catch (error) {
+      //애플 로그인 실패
+      return null;
+    }
+  }
+}

--- a/lib/data/repository/social_login_repository/kakao_login_impl.dart
+++ b/lib/data/repository/social_login_repository/kakao_login_impl.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/services.dart';
-import 'package:frontend/domain/repository/social_login_repository.dart';
+import 'package:frontend/domain/repository/social_login_repository/kakao_login_repository.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
-class KakaoLoginImpl implements SocialLoginRepository {
+class KakaoLoginImpl implements KakaoLoginRepository {
   @override
   Future<OAuthToken?> login() async {
     OAuthToken token;
@@ -43,6 +43,16 @@ class KakaoLoginImpl implements SocialLoginRepository {
 
   @override
   Future<UserIdResponse?> logout() async {
+    try {
+      final UserIdResponse response = await UserApi.instance.logout();
+      return response;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  @override
+  Future<UserIdResponse?> withdrawal() async {
     try {
       final UserIdResponse response = await UserApi.instance.unlink();
       return response;

--- a/lib/di/getx_binding_builder_call_back.dart
+++ b/lib/di/getx_binding_builder_call_back.dart
@@ -1,8 +1,10 @@
 import 'package:frontend/data/repository/access_token_repository_impl.dart';
-import 'package:frontend/data/repository/kakao_login_impl.dart';
+import 'package:frontend/data/repository/social_login_repository/apple_login_impl.dart';
 import 'package:frontend/data/repository/server_login_repository_impl.dart';
+import 'package:frontend/data/repository/social_login_repository/kakao_login_impl.dart';
 import 'package:frontend/domain/use_case/access_token_use_case.dart';
-import 'package:frontend/domain/use_case/kakao_login_use_case.dart';
+import 'package:frontend/domain/use_case/social_login_use_case/apple_login_use_case.dart';
+import 'package:frontend/domain/use_case/social_login_use_case/kakao_login_use_case.dart';
 import 'package:frontend/presentation/diary/diary_view_model.dart';
 import 'package:frontend/presentation/login/login_terms_information/login_terms_information_viewmodel.dart';
 import 'package:frontend/presentation/login/login_view_model.dart';
@@ -12,11 +14,17 @@ import 'package:frontend/presentation/on_boarding/on_boarding_nickname/on_boardi
 import 'package:get/get.dart';
 
 final KakaoLoginImpl kakaoLoginImpl = KakaoLoginImpl();
+final AppleLoginImpl appleLoginImpl = AppleLoginImpl();
 final ServerLoginRepositoryImpl serverLoginImpl = ServerLoginRepositoryImpl();
 
 //use case
 final KakaoLoginUseCase kakaoLoginUseCase = KakaoLoginUseCase(
   socialLoginRepository: kakaoLoginImpl,
+  serverLoginRepository: serverLoginImpl,
+);
+
+final AppleLoginUseCase appleLoginUseCase = AppleLoginUseCase(
+  socialLoginRepository: appleLoginImpl,
   serverLoginRepository: serverLoginImpl,
 );
 
@@ -28,6 +36,7 @@ void getLoginBinding() {
   Get.put(LoginViewModel(
     kakaoLoginUseCase: kakaoLoginUseCase,
     accessTokenUseCase: accessTokenUseCase,
+    appleLoginUseCase: appleLoginUseCase,
   ));
 }
 

--- a/lib/domain/repository/social_login_repository/apple_login_repository.dart
+++ b/lib/domain/repository/social_login_repository/apple_login_repository.dart
@@ -1,0 +1,5 @@
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+
+abstract class AppleLoginRepository {
+  Future<AuthorizationCredentialAppleID?> login();
+}

--- a/lib/domain/repository/social_login_repository/kakao_login_repository.dart
+++ b/lib/domain/repository/social_login_repository/kakao_login_repository.dart
@@ -1,7 +1,9 @@
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
-abstract class SocialLoginRepository {
+abstract class KakaoLoginRepository {
   Future<OAuthToken?> login();
 
   Future<UserIdResponse?> logout();
+
+  Future<UserIdResponse?> withdrawal();
 }

--- a/lib/domain/use_case/social_login_use_case/kakao_login_use_case.dart
+++ b/lib/domain/use_case/social_login_use_case/kakao_login_use_case.dart
@@ -1,0 +1,85 @@
+import 'package:frontend/core/result.dart';
+import 'package:frontend/data/data_source/local_data/local_secure_data_source.dart';
+import 'package:frontend/domain/model/social_login_result.dart';
+import 'package:frontend/domain/repository/server_login_repository.dart';
+import 'package:frontend/domain/repository/social_login_repository/kakao_login_repository.dart';
+import 'package:frontend/res/constants.dart';
+import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
+
+class KakaoLoginUseCase {
+  final KakaoLoginRepository socialLoginRepository;
+  final ServerLoginRepository serverLoginRepository;
+
+  KakaoLoginUseCase({
+    required this.socialLoginRepository,
+    required this.serverLoginRepository,
+  });
+
+  Future<SocialLoginResult> getKakaoSocialId() async {
+    //카카오 social id 및 email 얻기
+    String email = '';
+    String socialId = '';
+
+    final OAuthToken? kakaoLoginResult = await socialLoginRepository.login();
+    if (kakaoLoginResult != null) {
+      User user = await UserApi.instance.me();
+
+      email = user.kakaoAccount?.email ?? '';
+      socialId = '${user.id}';
+    }
+
+    return SocialLoginResult(
+      email: email,
+      socialId: socialId,
+    );
+  }
+
+  Future<SocialIDCheck> checkMember(String socialId) async {
+    //멤버 조회
+    return await serverLoginRepository.checkMember(socialId);
+  }
+
+  Future<Result<String>> login(String socialId) async {
+    //social id를 사용하여 서버에 login
+    final loginResult = await loginProcess(socialId);
+    return loginResult;
+  }
+
+  Future<bool> signup(String email, String socialId) async {
+    //social id를 사용하여 회원 가입
+    final bool result =
+        await serverLoginRepository.signup(email, 'KAKAO', socialId);
+
+    return result;
+  }
+
+  Future<Result<String>> loginProcess(String socialId) async {
+    String accessToken = '';
+    //로그인 api 호출
+    final loginResult = await serverLoginRepository.login('KAKAO', socialId);
+
+    return await loginResult.when(
+      success: (loginData) async {
+        //secure store에 refresh token 저장.
+        await LocalSecureDataSource()
+            .saveData(refreshTokenKey, loginData.refreshToken);
+
+        //access token은 return하기 위해 다른 변수에 저장.
+        accessToken = loginData.accessToken;
+        return Result.success(accessToken);
+      },
+      error: (message) {
+        //로그인 에러 처리
+        return Result.error(message);
+      },
+    );
+  }
+
+  Future<UserIdResponse?> logout() async {
+    return await socialLoginRepository.logout();
+  }
+
+  Future<UserIdResponse?> withdrawal() async {
+    return await socialLoginRepository.withdrawal();
+  }
+}

--- a/lib/presentation/diary/diary_view_model.dart
+++ b/lib/presentation/diary/diary_view_model.dart
@@ -1,4 +1,4 @@
-import 'package:frontend/domain/use_case/kakao_login_use_case.dart';
+import 'package:frontend/domain/use_case/social_login_use_case/kakao_login_use_case.dart';
 import 'package:get/get.dart';
 
 class DiaryViewModel extends GetxController {
@@ -7,8 +7,6 @@ class DiaryViewModel extends GetxController {
   DiaryViewModel({
     required this.kakaoLoginUseCase,
   });
-
-
 
   Future<void> logout() async {
     await kakaoLoginUseCase.logout();

--- a/lib/presentation/login/login_screen.dart
+++ b/lib/presentation/login/login_screen.dart
@@ -48,7 +48,7 @@ class LoginScreen extends GetView<LoginViewModel> {
             ),
             InkWell(
               onTap: () async {
-                await controller.login();
+                await controller.connectKakaoLogin();
               },
               child: const KakaoLoginWidget(),
             ),
@@ -56,7 +56,9 @@ class LoginScreen extends GetView<LoginViewModel> {
               height: 12.h,
             ),
             InkWell(
-              onTap: () {},
+              onTap: () async {
+                await controller.connectAppleLogin();
+              },
               child: const AppleLoginWidget(),
             ),
             SizedBox(

--- a/lib/presentation/login/login_terms_information/login_terms_information_viewmodel.dart
+++ b/lib/presentation/login/login_terms_information/login_terms_information_viewmodel.dart
@@ -1,4 +1,4 @@
-import 'package:frontend/domain/use_case/kakao_login_use_case.dart';
+import 'package:frontend/domain/use_case/social_login_use_case/kakao_login_use_case.dart';
 import 'package:get/get.dart';
 
 class LoginTermsInformationViewModel extends GetxController {

--- a/lib/presentation/login/login_view_model.dart
+++ b/lib/presentation/login/login_view_model.dart
@@ -38,7 +38,7 @@ class LoginViewModel extends GetxController {
     switch (checkMemberResult) {
       case SocialIDCheck.existMember:
         //로그인
-        await _onLoginAndMoveHome();
+        await _onLoginAndMoveHome(isSocialKakao: true);
         break;
       case SocialIDCheck.notMember:
         //멤버가 아니면 약관 동의 페이지 이동
@@ -62,16 +62,15 @@ class LoginViewModel extends GetxController {
       Get.snackbar('알림', '애플 세션과 연결이 실패했습니다.');
       return;
     }
-
     //멤버 조회
     final checkMemberResult =
-        await kakaoLoginUseCase.checkMember(state.value.socialId);
+        await appleLoginUseCase.checkMember(state.value.socialId);
 
     //조회 결과
     switch (checkMemberResult) {
       case SocialIDCheck.existMember:
         //로그인
-        await _onLoginAndMoveHome();
+        await _onLoginAndMoveHome(isSocialKakao: false);
         break;
       case SocialIDCheck.notMember:
         //멤버가 아니면 약관 동의 페이지 이동
@@ -106,8 +105,11 @@ class LoginViewModel extends GetxController {
     return true;
   }
 
-  Future<void> _onLoginAndMoveHome() async {
-    final loginResult = await kakaoLoginUseCase.login(state.value.socialId);
+  Future<void> _onLoginAndMoveHome({required isSocialKakao}) async {
+    final loginResult = isSocialKakao
+        ? await kakaoLoginUseCase.login(state.value.socialId)
+        : await appleLoginUseCase.login(state.value.socialId);
+
     await loginResult.when(
       success: (accessToken) async {
         await accessTokenUseCase.setAccessToken(accessToken);

--- a/lib/presentation/on_boarding/on_boarding_job/on_boarding_job_viewmodel.dart
+++ b/lib/presentation/on_boarding/on_boarding_job/on_boarding_job_viewmodel.dart
@@ -1,5 +1,5 @@
 import 'package:frontend/domain/use_case/access_token_use_case.dart';
-import 'package:frontend/domain/use_case/kakao_login_use_case.dart';
+import 'package:frontend/domain/use_case/social_login_use_case/kakao_login_use_case.dart';
 import 'package:frontend/presentation/home/home_screen.dart';
 import 'package:frontend/res/constants.dart';
 import 'package:get/get.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -700,6 +700,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  sign_in_with_apple:
+    dependency: "direct main"
+    description:
+      name: sign_in_with_apple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.0"
+  sign_in_with_apple_platform_interface:
+    dependency: transitive
+    description:
+      name: sign_in_with_apple_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  sign_in_with_apple_web:
+    dependency: transitive
+    description:
+      name: sign_in_with_apple_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   http: ^0.13.5
   dio: ^4.0.6
   fluttertoast: ^8.1.1
+  sign_in_with_apple: ^4.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
>PR message template 입니다.
아래 사항들을 작성 하시고 PR 해주세요!
## 수정 사항 간략한 한줄 요약
- 애플로그인 API 연결 및 카카오 회원탈퇴 기능 추가
- 카카오 로그인의 연결끊기 기능 추가

## 변경로직 및 수정 사항들의 자세한 내용
- 기존 코드에 더해서 애플로그인을 구현하였습니다.
- 소셜 로그인 관련된 곳은 디렉토리로 묶어서 관리했습니다.

## 특이 사항 및 리뷰 받고 싶은 코드
- 애플의 로그아웃 기능이 아직 없는듯 합니다 ㅠㅠ(https://github.com/aboutyou/dart_packages/issues/84)  애플 관련 로그인은 토큰 세션만 끊어주면 문제없는지 테스트를 하고 싶지만 아이폰 기기가 없어 테스트를 못하여 어떤 영향을 끼치는지 확인을 못하고 있습니다. **아마 문제는 없을것 같은데 테스트 가능할때 해보겠습니다!**
- 추가로 처음으로 애플 로그인 및 클린 아키텍쳐를 진우님 생각대로 제가 잘 구현 했는지 잘 됐는지 궁금합니다!